### PR TITLE
feat: add devtools

### DIFF
--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -9,6 +9,7 @@ import { settingsDiskStore } from './disk-storage'
 import { shallow } from 'zustand/shallow'
 import { DEFAULT_USER_SETTINGS } from './constants'
 import { loadHistoryJson } from './spotify/loaders/history'
+import { is } from '@electron-toolkit/utils'
 
 export const userStateSlice = (state: RemoteApplicationState): UserExposedState => ({
   isPlaying: state.isPlaying,
@@ -21,6 +22,7 @@ export const userStateSlice = (state: RemoteApplicationState): UserExposedState 
 })
 
 export const remoteStateSlice = (state: ApplicationState): RemoteApplicationState => ({
+  isDevMode: state.isDevMode,
   isUpdateAvailable: state.isUpdateAvailable,
   isLoggedIn: state.isLoggedIn,
   userSettings: state.userSettings,
@@ -32,6 +34,7 @@ const historyJson = loadHistoryJson()
 
 export const applicationStore = create<ApplicationState>()(
   subscribeWithSelector((_set) => ({
+    isDevMode: is.dev,
     isUpdateAvailable: null,
     isLoggedIn: null,
     isPlaying: false,

--- a/src/main/test/custom-test.ts
+++ b/src/main/test/custom-test.ts
@@ -155,6 +155,12 @@ const csvWriter = {
   on: vi.fn().mockImplementation(() => csvWriter)
 }
 
+vi.mock('@electron-toolkit/utils', () => ({
+  is: {
+    dev: false
+  }
+}))
+
 vi.mock('@fast-csv/format', () => ({
   writeToPath: vi.fn().mockImplementation(() => csvWriter)
 }))

--- a/src/renderer/preferences/src/App.tsx
+++ b/src/renderer/preferences/src/App.tsx
@@ -39,7 +39,9 @@ export const App = () => {
     enableWebWidget,
     webWidgetPort,
     webWidgetPortError,
-    enableHistory
+    enableHistory,
+    isDevMode,
+    dev_showSpotifyPlayer,
   } = useRemoteApplicationStore((state) => ({
     isUpdateAvailable: state?.isUpdateAvailable,
     isLoggedIn: state?.isLoggedIn,
@@ -52,7 +54,9 @@ export const App = () => {
     enableWebWidget: state?.userSettings.enableWebWidget,
     webWidgetPort: state?.userSettings.webWidgetPort,
     webWidgetPortError: state?.webWidgetPortError,
-    enableHistory: state?.userSettings.enableHistory
+    enableHistory: state?.userSettings.enableHistory,
+    isDevMode: state?.isDevMode,
+    dev_showSpotifyPlayer: state?.userSettings.dev_showSpotifyPlayer,
   }))
 
   useLayoutEffect(() => {
@@ -218,6 +222,30 @@ export const App = () => {
           </>
         ) : null}
       </div>
+      {isDevMode ? (
+        <div className="section-area">
+          <button className="item" disabled>
+            <div className="icon"></div>
+            <div className="text">Dev Tools</div>
+          </button>
+          
+        <button
+          className="item"
+          onClick={() =>
+            window.electron.ipcRenderer.send('set-user-settings', {
+              dev_showSpotifyPlayer: !dev_showSpotifyPlayer
+            })
+          }
+        >
+          <div className="icon">
+            {typeof dev_showSpotifyPlayer !== 'undefined' ? (
+              <input type="checkbox" checked={dev_showSpotifyPlayer} readOnly />
+            ) : null}
+          </div>
+          <div className="text"> Show Spotify Player</div>
+        </button>
+        </div>
+      ) : null}
       <div className="section-area">
         {isUpdateAvailable ? (
           <button className="item" onClick={() => window.electron.ipcRenderer.send('get-update')}>

--- a/src/renderer/preferences/src/App.tsx
+++ b/src/renderer/preferences/src/App.tsx
@@ -238,9 +238,7 @@ export const App = () => {
           }
         >
           <div className="icon">
-            {typeof dev_showSpotifyPlayer !== 'undefined' ? (
-              <input type="checkbox" checked={dev_showSpotifyPlayer} readOnly />
-            ) : null}
+            <input type="checkbox" checked={dev_showSpotifyPlayer ?? false} readOnly />
           </div>
           <div className="text"> Show Spotify Player</div>
         </button>

--- a/src/shared/types/state.ts
+++ b/src/shared/types/state.ts
@@ -30,6 +30,7 @@ export type TrackHistoryEntry = {
 }
 
 export type UserSettings = {
+  dev_showSpotifyPlayer?: boolean
   emptyFilesWhenPaused: boolean
   saveJsonFile: boolean
   saveSmallImage: boolean
@@ -51,6 +52,7 @@ export interface UserExposedState {
 }
 
 export interface RemoteApplicationState extends UserExposedState {
+  isDevMode: boolean
   webWidgetPortError: boolean
   isUpdateAvailable: boolean | null
   isLoggedIn: boolean | null


### PR DESCRIPTION
This adds some tools to the preferences window that shows when running with `pnpm run dev`.

This makes debugging a little easier by being able to force show the Spotify window with dev tools.